### PR TITLE
Added buildstorage method for cube object

### DIFF
--- a/pydundas/rest/cube.py
+++ b/pydundas/rest/cube.py
@@ -92,6 +92,10 @@ class Cube:
         """Triggers a warehousing."""
         self.api.session.post('datacube/warehouse/' + self.id, json={})
 
+    def buildstorage(self):
+        """Triggers a 'Build Warehouse' event"""
+        self.api.session.post('datacube/buildstorage/' + self.id, json={})
+
     def json(self):
         """Return proper JSONised data."""
         return json.dumps(self.data)


### PR DESCRIPTION
The existing warehouse() method may be deprecated. The buildstorage() method can trigger either a warehouse or in-memory cube to run and refresh its data.